### PR TITLE
Lock h5py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy==1.16.2
 tensorflow==1.15.2
 keras==2.2.4
 scikit-learn==0.22.1
+h5py==2.9.0


### PR DESCRIPTION
An update to h5py broke this model. Locking h5py to 2.9.0