### PR TITLE
Upgrade tensorflow to 2.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - 3.6
+  - 3.8
 services:
   - docker
 install:

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,14 +14,14 @@
 # limitations under the License.
 #
 
-FROM quay.io/codait/max-base:v1.4.0
+FROM quay.io/codait/max-base:v1.5.1
 
 COPY requirements.txt .
 
 RUN pip install -r requirements.txt
- 
+
 COPY . .
-    
+
 EXPOSE 5000
 
 CMD python app.py

--- a/api/predict.py
+++ b/api/predict.py
@@ -16,7 +16,7 @@
 
 from core.model import ModelWrapper
 from maxfw.core import MAX_API, PredictAPI
-from flask_restplus import fields
+from flask_restx import fields
 from werkzeug.datastructures import FileStorage
 from config import DEFAULT_MODEL, MODELS
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-numpy==1.16.2
-tensorflow==1.15.2
-keras==2.2.4
-scikit-learn==0.22.1
-h5py==2.9.0
+tensorflow==2.6.0
+keras==2.6.0
+scikit-learn==0.22.2
+# numpy and h5py not specified here because tensorflow has specifies a major.minor version range for them


### PR DESCRIPTION
h5py and numpy are unpinned because tensorflow has specified major.minor for these two dependencies.